### PR TITLE
Disable sorting by default, but add a sort flag

### DIFF
--- a/cmd/yamlfmt/main.go
+++ b/cmd/yamlfmt/main.go
@@ -27,6 +27,7 @@ var (
 	write  bool
 	doDiff bool
 	doFail bool
+	doSort bool
 
 	errRequiresFmt = errors.New("RequiresFmt")
 )
@@ -48,8 +49,9 @@ func run(in io.Reader, out io.Writer, args []string) error {
 	flags.BoolVar(&write, "w", false, "write result to (source) file instead of stdout")
 	flags.BoolVar(&doDiff, "d", false, "display diffs instead of rewriting files")
 	flags.BoolVar(&doFail, "f", false, "exit non zero if changes detected")
+	flags.BoolVar(&doSort, "s", false, "sort maps & sequences, WARNING: This may break anchors & aliases")
 	flags.Usage = func() {
-		fmt.Fprintf(os.Stderr, "formats yaml files with 2 space indent, sorted dicts and non-indented lists\n")
+		fmt.Fprintf(os.Stderr, "formats yaml files with 2 space indent and non-indented sequences\n")
 		fmt.Fprintf(os.Stderr, "usage: yamlfmt [flags] [path ...]\n")
 		flags.PrintDefaults()
 	}
@@ -59,7 +61,7 @@ func run(in io.Reader, out io.Writer, args []string) error {
 		if write {
 			return fmt.Errorf("error: cannot use -w with standard input")
 		}
-		if err := processFile("<standard input>", in, out, true); err != nil {
+		if err := processFile("<standard input>", in, out, true, doSort); err != nil {
 			return err
 		}
 	}
@@ -70,9 +72,9 @@ func run(in io.Reader, out io.Writer, args []string) error {
 		case err != nil:
 			return err
 		case dir.IsDir():
-			return walkDir(path)
+			return walkDir(path, doSort)
 		default:
-			if err := processFile(path, nil, os.Stdout, false); err != nil {
+			if err := processFile(path, nil, os.Stdout, false, doSort); err != nil {
 				return err
 			}
 		}
@@ -81,7 +83,7 @@ func run(in io.Reader, out io.Writer, args []string) error {
 }
 
 // If in == nil, the source is the contents of the file with the given filename.
-func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error {
+func processFile(filename string, in io.Reader, out io.Writer, stdin bool, sort bool) error {
 	var perm os.FileMode = 0644
 	if in == nil {
 		f, err := os.Open(filename)
@@ -102,7 +104,7 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 		return err
 	}
 
-	res, err := yamlfmt.Format(bytes.NewBuffer(src))
+	res, err := yamlfmt.Format(bytes.NewBuffer(src), sort)
 	if err != nil {
 		return err
 	}
@@ -150,11 +152,12 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 
 type fileVisitor struct {
 	changesDetected bool
+	sort            bool
 }
 
 func (fv *fileVisitor) visitFile(path string, f os.FileInfo, err error) error {
 	if err == nil && isYamlFile(f) {
-		err = processFile(path, nil, os.Stdout, false)
+		err = processFile(path, nil, os.Stdout, false, fv.sort)
 	}
 	// Don't complain if a file was deleted in the meantime (i.e.
 	// the directory changed concurrently while running gofmt).
@@ -167,8 +170,8 @@ func (fv *fileVisitor) visitFile(path string, f os.FileInfo, err error) error {
 	return nil
 }
 
-func walkDir(path string) error {
-	fv := fileVisitor{}
+func walkDir(path string, sort bool) error {
+	fv := fileVisitor{sort: sort}
 	filepath.Walk(path, fv.visitFile)
 	var err error
 	if fv.changesDetected {

--- a/format.go
+++ b/format.go
@@ -11,10 +11,10 @@ import (
 const indent = 2
 
 // Format reads in a yaml document and outputs the yaml in a standard format.
-// Dictionary keys are sorted lexicagraphically
+// If sort is true than dictionary keys are sorted lexicographically
 // Indents are set to 2
 // Lists are not indented
-func Format(r io.Reader) ([]byte, error) {
+func Format(r io.Reader, sort bool) ([]byte, error) {
 	dec := yaml.NewDecoder(r)
 	out := bytes.NewBuffer(nil)
 	for {
@@ -30,7 +30,12 @@ func Format(r io.Reader) ([]byte, error) {
 			return nil, fmt.Errorf("failed decoding: %s", err)
 		}
 		out.WriteString("---\n")
-		if err := enc.Encode(sortYAML(&doc)); err != nil {
+		if sort {
+			err = enc.Encode(sortYAML(&doc))
+		} else {
+			err = enc.Encode(&doc)
+		}
+		if err != nil {
 			return nil, fmt.Errorf("failed encoding: %s", err)
 		}
 		enc.Close()

--- a/format_test.go
+++ b/format_test.go
@@ -27,7 +27,7 @@ k:
     c: i
 `
 	exp := []byte(expected)
-	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)))
+	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)), true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}
@@ -50,7 +50,7 @@ bar:
   foo: baz # comment
 `
 	exp := []byte(expected)
-	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)))
+	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)), true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}
@@ -97,7 +97,7 @@ k:
     c: i
 `
 	exp := []byte(expected)
-	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)))
+	out, err := yamlfmt.Format(bytes.NewReader([]byte(in)), true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}


### PR DESCRIPTION
Per the yaml spec maps are unordered and sequences are ordered. Sorting
maps may break anchors & aliases. Sorting sequences may change their
meaning for the consuming application. So disable sorting by default.

Fixes: #15